### PR TITLE
ServiceProvider fixes, readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This is especially useful in a miroservice architecture where multiple services 
 
 ## Requirements
 
--   Laravel (tested with version 5.8)
--   or Lumen (tested with version 5.8)
+-   Laravel (tested with version 8.0)
+-   or Lumen (tested with version 8.0)
 
 ## Installation
 You can install the package via composer
 ```bash
-composer require jeylabs/laravel-sns-sqs-sub-pub 
+composer require mvjacobs/laravel-sns-sqs-sub-pub 
 ```
 You can optionally publish the config file with:
 ```bash

--- a/src/SnsSqsPubSubServiceProvider.php
+++ b/src/SnsSqsPubSubServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace Mvjacobs\SnsSqsPubSub;
 
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\ServiceProvider;
 use Mvjacobs\SnsSqsPubSub\Queue\Connectors\SnsConnector;
@@ -23,16 +24,16 @@ class SnsSqsPubSubServiceProvider extends ServiceProvider
     /**
      * Bootstrap services.
      *
+     * @param QueueManager $manager
      * @return void
+     * @throws BindingResolutionException
      */
-    public function boot()
+    public function boot(QueueManager $manager)
     {
-        $this->app->afterResolving(QueueManager::class, function (QueueManager $manager) {
-            $config = $this->app->make(Repository::class);
-            $manager->addConnector('sns-sqs-sub-pub', function () use ($config) {
-                $map = new JobMap($config->get('sns-sqs-sub-pub.map'));
-                return new SnsConnector($map);
-            });
+        $config = $this->app->make(Repository::class);
+        $manager->addConnector('sns-sqs-sub-pub', function () use ($config) {
+            $map = new JobMap($config->get('sns-sqs-sub-pub.map'));
+            return new SnsConnector($map);
         });
     }
 


### PR DESCRIPTION
`$this->app->afterResolving(QueueManager::class, function (QueueManager $manager)` does not appear to ever be firing because the QueueManager has already been resolved by the time this service provider boots. Presumably, this is due to internal Laravel changes.

Instead, we can just dependency inject the manager.